### PR TITLE
Add observability logging for LiteLLM calls

### DIFF
--- a/webapp/packages/api/user-service/agent_factory/__init__.py
+++ b/webapp/packages/api/user-service/agent_factory/__init__.py
@@ -12,8 +12,11 @@ import asyncio
 
 from services.database_service import get_database_service
 from services.llm_service import call_llm
+from services.litellm_logger import ensure_litellm_logging
 from config import settings
 from config.provider_config import PROVIDER_CONFIG
+
+ensure_litellm_logging()
 
 async def generate_agent_code(request: GenerateCodeRequest):
     """

--- a/webapp/packages/api/user-service/services/chat_service.py
+++ b/webapp/packages/api/user-service/services/chat_service.py
@@ -7,6 +7,10 @@ import asyncio
 from litellm import acompletion, ModelResponse
 import litellm
 
+from services.litellm_logger import ensure_litellm_logging
+
+ensure_litellm_logging()
+
 # Configure litellm
 litellm.drop_params = True
 litellm.set_verbose = False

--- a/webapp/packages/api/user-service/services/litellm_logger.py
+++ b/webapp/packages/api/user-service/services/litellm_logger.py
@@ -1,0 +1,62 @@
+import json
+from typing import Any
+
+import litellm
+from litellm.integrations.custom_logger import CustomLogger
+
+from services.observability_service import get_observability_service
+
+
+class ObservabilityLiteLLMLogger(CustomLogger):
+    """LiteLLM callback that forwards StandardLoggingPayload to observability."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.observability = get_observability_service()
+
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        await self._log_standard_payload(kwargs, level="INFO")
+
+    async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
+        await self._log_standard_payload(kwargs, level="ERROR")
+
+    async def _log_standard_payload(self, kwargs: Any, level: str) -> None:
+        payload = kwargs.get("standard_logging_object") if isinstance(kwargs, dict) else None
+        if payload is None:
+            return
+
+        try:
+            serialized_payload = json.loads(json.dumps(payload, default=str))
+        except Exception:
+            serialized_payload = {"error": "Failed to serialize StandardLoggingPayload"}
+
+        status = serialized_payload.get("status", "unknown")
+        message = f"LiteLLM call completed with status: {status}"
+
+        self.observability.log(
+            level=level,
+            event_type="litellm_call",
+            message=message,
+            metadata={"standardLoggingPayload": serialized_payload},
+        )
+
+
+_configured_logger = False
+
+
+def ensure_litellm_logging() -> None:
+    """Attach the observability logger to LiteLLM callbacks if not already set."""
+    global _configured_logger
+    if _configured_logger:
+        return
+
+    callbacks = getattr(litellm, "callbacks", [])
+    if not any(isinstance(cb, ObservabilityLiteLLMLogger) for cb in callbacks):
+        callbacks.append(ObservabilityLiteLLMLogger())
+        litellm.callbacks = callbacks
+
+    _configured_logger = True
+
+
+# Ensure the logger is registered when the module is imported.
+ensure_litellm_logging()

--- a/webapp/packages/api/user-service/services/llm_service.py
+++ b/webapp/packages/api/user-service/services/llm_service.py
@@ -1,8 +1,12 @@
-import litellm
 import asyncio
 import json
 from config.provider_config import PROVIDER_CONFIG
 from typing import Any, Dict, List, Tuple, Optional
+import litellm
+
+from services.litellm_logger import ensure_litellm_logging
+
+ensure_litellm_logging()
 
 async def call_llm(
     provider: str,


### PR DESCRIPTION
## Summary
- add an ObservabilityLiteLLMLogger callback to forward LiteLLM StandardLoggingPayload data to the observability service
- register the callback across LiteLLM usage sites so every call emits the standardized logging event

## Testing
- python -m compileall webapp/packages/api/user-service

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692df09a01848323b989139a19efd1e1)