### PR TITLE
Adjust profile navigation menu options

### DIFF
--- a/webapp/packages/webui/src/components/ProfileMenu.jsx
+++ b/webapp/packages/webui/src/components/ProfileMenu.jsx
@@ -1,12 +1,14 @@
 // webapp/packages/webui/src/components/ProfileMenu.jsx
 import React, { useState } from 'react';
-import { IconButton, Menu, MenuItem } from '@mui/material';
+import { Divider, IconButton, Menu, MenuItem } from '@mui/material';
 import AccountCircle from '@mui/icons-material/AccountCircle';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 
 const ProfileMenu = () => {
   const { logout } = useAuth();
   const [anchorEl, setAnchorEl] = useState(null);
+  const navigate = useNavigate();
 
   const handleMenu = (event) => {
     setAnchorEl(event.currentTarget);
@@ -18,6 +20,11 @@ const ProfileMenu = () => {
 
   const handleLogout = () => {
     logout();
+    handleClose();
+  };
+
+  const handleNavigate = (path) => {
+    navigate(path);
     handleClose();
   };
 
@@ -48,6 +55,10 @@ const ProfileMenu = () => {
         open={Boolean(anchorEl)}
         onClose={handleClose}
       >
+        <MenuItem onClick={() => handleNavigate('/profile/basic')}>Basic Info</MenuItem>
+        <MenuItem onClick={() => handleNavigate('/profile/usage')}>Usage</MenuItem>
+        <MenuItem onClick={() => handleNavigate('/profile/billing')}>Billing</MenuItem>
+        <Divider />
         <MenuItem onClick={handleLogout}>Logout</MenuItem>
       </Menu>
     </div>

--- a/webapp/packages/webui/src/components/profile/BasicInfoTab.jsx
+++ b/webapp/packages/webui/src/components/profile/BasicInfoTab.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Box, Typography, Paper, Stack, Divider } from '@mui/material';
+import { useAuth } from '../../contexts/AuthContext';
+
+const InfoRow = ({ label, value }) => (
+  <Stack direction="row" justifyContent="space-between" alignItems="center" py={1}>
+    <Typography variant="subtitle2" color="text.secondary">
+      {label}
+    </Typography>
+    <Typography variant="body1" sx={{ ml: 2 }}>
+      {value || 'Not provided'}
+    </Typography>
+  </Stack>
+);
+
+InfoRow.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]),
+};
+
+const BasicInfoTab = () => {
+  const { user } = useAuth();
+
+  return (
+    <Box>
+      <Typography variant="h6" gutterBottom>
+        Basic Information
+      </Typography>
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        {user ? (
+          <Stack spacing={0}>
+            <InfoRow label="Display Name" value={user.displayName} />
+            <Divider />
+            <InfoRow label="Email" value={user.email} />
+            <Divider />
+            <InfoRow label="User ID" value={user.uid} />
+          </Stack>
+        ) : (
+          <Typography color="text.secondary">
+            No user information available.
+          </Typography>
+        )}
+      </Paper>
+    </Box>
+  );
+};
+
+export default BasicInfoTab;

--- a/webapp/packages/webui/src/components/profile/BillingInfoTab.jsx
+++ b/webapp/packages/webui/src/components/profile/BillingInfoTab.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Box, Typography, Paper } from '@mui/material';
+
+const BillingInfoTab = () => {
+  return (
+    <Box>
+      <Typography variant="h6" gutterBottom>
+        Billing
+      </Typography>
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <Typography color="text.secondary">
+          Billing is not enabled in the open source version.
+        </Typography>
+      </Paper>
+    </Box>
+  );
+};
+
+export default BillingInfoTab;

--- a/webapp/packages/webui/src/components/profile/UsageInfoTab.jsx
+++ b/webapp/packages/webui/src/components/profile/UsageInfoTab.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Box, Typography, Paper } from '@mui/material';
+
+const UsageInfoTab = () => {
+  return (
+    <Box>
+      <Typography variant="h6" gutterBottom>
+        Usage
+      </Typography>
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <Typography color="text.secondary">
+          Usage insights are coming soon. We&apos;re working on adding detailed metrics for your account.
+        </Typography>
+      </Paper>
+    </Box>
+  );
+};
+
+export default UsageInfoTab;

--- a/webapp/packages/webui/src/config/routesConfig.jsx
+++ b/webapp/packages/webui/src/config/routesConfig.jsx
@@ -20,6 +20,7 @@ import CanvasScreen from '../pages/DemoCreationFlow/CanvasScreen';
 import SaveDemoScreen from '../pages/DemoCreationFlow/SaveDemoScreen';
 import { AgentCreationFlowProvider } from '../pages/AgentCreationFlow/AgentCreationFlowContext';
 import { DemoCreationFlowProvider } from '../pages/DemoCreationFlow/DemoCreationFlowContext';
+import ProfilePage from '../pages/ProfilePage';
 // import extendRoutes from '../extensions/routes/routeExtensions';
 
 export const defaultRoutes = [
@@ -44,6 +45,10 @@ export const defaultRoutes = [
   {
     path: '/demo-apps',
     element: <DemoAppsPage />,
+  },
+  {
+    path: '/profile/:section?',
+    element: <ProfilePage />,
   },
   {
     path: '/demos/:demoId',

--- a/webapp/packages/webui/src/pages/ProfilePage.jsx
+++ b/webapp/packages/webui/src/pages/ProfilePage.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import { useParams } from 'react-router-dom';
+import BasicInfoTab from '../components/profile/BasicInfoTab';
+import UsageInfoTab from '../components/profile/UsageInfoTab';
+import BillingInfoTab from '../components/profile/BillingInfoTab';
+
+const sections = {
+  basic: { label: 'Basic Info', component: <BasicInfoTab /> },
+  usage: { label: 'Usage', component: <UsageInfoTab /> },
+  billing: { label: 'Billing', component: <BillingInfoTab /> },
+};
+
+const ProfilePage = () => {
+  const { section } = useParams();
+  const sectionKey = section && sections[section] ? section : 'basic';
+  const activeSection = sections[sectionKey];
+
+  return (
+    <Box>
+      <Typography variant="h4" gutterBottom>
+        Profile
+      </Typography>
+      <Typography variant="h6" gutterBottom>
+        {activeSection.label}
+      </Typography>
+      <Box sx={{ pt: 1 }}>{activeSection.component}</Box>
+    </Box>
+  );
+};
+
+export default ProfilePage;

--- a/webapp/packages/webui/src/pages/ProfilePage.jsx
+++ b/webapp/packages/webui/src/pages/ProfilePage.jsx
@@ -21,9 +21,6 @@ const ProfilePage = () => {
       <Typography variant="h4" gutterBottom>
         Profile
       </Typography>
-      <Typography variant="h6" gutterBottom>
-        {activeSection.label}
-      </Typography>
       <Box sx={{ pt: 1 }}>{activeSection.component}</Box>
     </Box>
   );


### PR DESCRIPTION
## Summary
- replace the profile page tabs with section-specific routes for basic info, usage, and billing
- update the profile menu to link directly to each section with a divider before logout
- keep /profile defaulting to the basic info section via the optional route parameter

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692df8d209708323b1014469d1317ebe)