### PR TITLE
Add user usage tracking and profile visualization

### DIFF
--- a/webapp/packages/api/user-service/models/user.py
+++ b/webapp/packages/api/user-service/models/user.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+from typing import List, Optional, Any
+
+from pydantic import BaseModel, Field
+from pydantic.alias_generators import to_camel
+from pydantic.config import ConfigDict
+
+
+class UsageEntry(BaseModel):
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    response_cost: float = Field(alias="responseCost")
+    metadata: Optional[Any] = None
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+
+class UsageInfo(BaseModel):
+    monthly_allowance: float = Field(default=100.0, alias="monthlyAllowance")
+    allowance_reset_date: float = Field(default=0.0, alias="allowanceResetDate")
+    spend_remaining: float = Field(default=100.0, alias="spendRemaining")
+    usage: List[UsageEntry] = Field(default_factory=list)
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+
+class BillingInfo(BaseModel):
+    plan: Optional[str] = None
+    status: Optional[str] = None
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+
+class BasicInfo(BaseModel):
+    display_name: Optional[str] = Field(default=None, alias="displayName")
+    email: Optional[str] = None
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+
+class User(BaseModel):
+    id: str = Field(alias="_id")
+    rev: Optional[str] = Field(default=None, alias="_rev")
+    created_at: datetime = Field(default_factory=datetime.utcnow, alias="createdAt")
+    updated_at: datetime = Field(default_factory=datetime.utcnow, alias="updatedAt")
+    basic_info: BasicInfo = Field(default_factory=BasicInfo, alias="basicInfo")
+    billing_info: BillingInfo = Field(default_factory=BillingInfo, alias="billingInfo")
+    usage_info: UsageInfo = Field(default_factory=UsageInfo, alias="usageInfo")
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)

--- a/webapp/packages/api/user-service/services/user_service.py
+++ b/webapp/packages/api/user-service/services/user_service.py
@@ -1,0 +1,86 @@
+from datetime import datetime
+from typing import Optional, Any
+
+from fastapi import HTTPException
+
+from models.user import User, UsageEntry
+
+
+class UserService:
+    def __init__(self, db_service):
+        self.db = db_service
+
+    def _create_default_user(self, user_id: str, basic_info: Optional[dict] = None) -> User:
+        now = datetime.utcnow()
+        basic_info = basic_info or {}
+        user = User(
+            _id=user_id,
+            created_at=now,
+            updated_at=now,
+            basic_info={
+                "displayName": basic_info.get("name") or basic_info.get("displayName"),
+                "email": basic_info.get("email"),
+            },
+        )
+        return user
+
+    def get_user(self, user_id: str, basic_info: Optional[dict] = None) -> User:
+        try:
+            doc = self.db.get("users", user_id)
+            return User(**doc)
+        except HTTPException as exc:
+            if exc.status_code != 404:
+                raise
+        user = self._create_default_user(user_id, basic_info)
+        return self.save_user(user)
+
+    def save_user(self, user: User) -> User:
+        user.updated_at = datetime.utcnow()
+        saved = self.db.save("users", user.id, user.model_dump(by_alias=True, mode="json"))
+        user.rev = saved.get("rev")
+        return user
+
+    def require_allowance(self, user_id: str, minimum_remaining: float = 1.0, basic_info: Optional[dict] = None) -> User:
+        user = self.get_user(user_id, basic_info)
+        if user.usage_info.spend_remaining <= minimum_remaining:
+            raise HTTPException(status_code=402, detail="Insufficient spend allowance to complete request")
+        return user
+
+    def set_monthly_allowance(self, user_id: str, amount: float, basic_info: Optional[dict] = None) -> User:
+        user = self.get_user(user_id, basic_info)
+        user.usage_info.monthly_allowance = amount
+        if user.usage_info.spend_remaining > amount:
+            user.usage_info.spend_remaining = amount
+        return self.save_user(user)
+
+    def set_reset_date(self, user_id: str, reset_date: float, basic_info: Optional[dict] = None) -> User:
+        user = self.get_user(user_id, basic_info)
+        user.usage_info.allowance_reset_date = reset_date
+        return self.save_user(user)
+
+    def reset_allowance(self, user_id: str, basic_info: Optional[dict] = None) -> User:
+        user = self.get_user(user_id, basic_info)
+        user.usage_info.spend_remaining = user.usage_info.monthly_allowance
+        user.usage_info.usage = []
+        return self.save_user(user)
+
+    def update_spend_remaining(self, user_id: str, spend_remaining: float, basic_info: Optional[dict] = None) -> User:
+        user = self.get_user(user_id, basic_info)
+        user.usage_info.spend_remaining = spend_remaining
+        return self.save_user(user)
+
+    def add_usage(self, user_id: str, response_cost: float, metadata: Optional[Any] = None, basic_info: Optional[dict] = None) -> User:
+        user = self.get_user(user_id, basic_info)
+        user.usage_info.usage.append(UsageEntry(responseCost=response_cost, metadata=metadata))
+        user.usage_info.spend_remaining = max(0.0, user.usage_info.spend_remaining - response_cost)
+        return self.save_user(user)
+
+
+_user_service_instance: Optional[UserService] = None
+
+
+def get_user_service(db_service):
+    global _user_service_instance
+    if _user_service_instance is None or _user_service_instance.db is not db_service:
+        _user_service_instance = UserService(db_service)
+    return _user_service_instance

--- a/webapp/packages/webui/src/components/profile/UsageInfoTab.jsx
+++ b/webapp/packages/webui/src/components/profile/UsageInfoTab.jsx
@@ -1,16 +1,130 @@
-import React from 'react';
-import { Box, Typography, Paper } from '@mui/material';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  Typography,
+  Paper,
+  Stack,
+  Divider,
+  LinearProgress,
+} from '@mui/material';
+import userService from '../../services/userService';
+
+const UsageBar = ({ date, cost, maxCost }) => {
+  const height = maxCost > 0 ? (cost / maxCost) * 160 : 0;
+  return (
+    <Box sx={{ flex: 1, minWidth: 48 }}>
+      <Box
+        sx={{
+          height,
+          bgcolor: 'primary.main',
+          borderRadius: 1,
+          transition: 'height 0.3s ease',
+        }}
+      />
+      <Typography variant="caption" display="block" sx={{ mt: 1 }}>
+        {date}
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        ${cost.toFixed(2)}
+      </Typography>
+    </Box>
+  );
+};
 
 const UsageInfoTab = () => {
+  const [profile, setProfile] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const loadProfile = async () => {
+      try {
+        setLoading(true);
+        const data = await userService.getProfile();
+        setProfile(data);
+      } catch (err) {
+        setError(err.message || 'Failed to load usage information');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadProfile();
+  }, []);
+
+  const usageSummary = useMemo(() => {
+    if (!profile?.usageInfo) return { chartData: [], maxCost: 0 };
+
+    const grouped = profile.usageInfo.usage.reduce((acc, entry) => {
+      const date = new Date(entry.timestamp).toISOString().split('T')[0];
+      const cost = Number(entry.responseCost || 0);
+      acc[date] = (acc[date] || 0) + cost;
+      return acc;
+    }, {});
+
+    const chartData = Object.entries(grouped)
+      .map(([date, cost]) => ({ date, cost }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+
+    const maxCost = chartData.reduce((max, item) => Math.max(max, item.cost), 0);
+
+    return { chartData, maxCost };
+  }, [profile]);
+
   return (
     <Box>
       <Typography variant="h6" gutterBottom>
         Usage
       </Typography>
       <Paper variant="outlined" sx={{ p: 2 }}>
-        <Typography color="text.secondary">
-          Usage insights are coming soon. We&apos;re working on adding detailed metrics for your account.
-        </Typography>
+        {loading && <LinearProgress />}
+        {!loading && error && (
+          <Typography color="error" gutterBottom>
+            {error}
+          </Typography>
+        )}
+        {!loading && !error && profile && (
+          <Stack spacing={2}>
+            <Stack direction="row" spacing={2}>
+              <Box sx={{ flex: 1 }}>
+                <Typography variant="subtitle2" color="text.secondary">
+                  Monthly Allowance
+                </Typography>
+                <Typography variant="h6">
+                  ${profile.usageInfo.monthlyAllowance.toFixed(2)}
+                </Typography>
+              </Box>
+              <Box sx={{ flex: 1 }}>
+                <Typography variant="subtitle2" color="text.secondary">
+                  Spend Remaining
+                </Typography>
+                <Typography variant="h6">
+                  ${profile.usageInfo.spendRemaining.toFixed(2)}
+                </Typography>
+              </Box>
+            </Stack>
+
+            <Divider />
+
+            <Typography variant="subtitle1">Usage by Date</Typography>
+            {usageSummary.chartData.length === 0 ? (
+              <Typography color="text.secondary">
+                No usage recorded yet.
+              </Typography>
+            ) : (
+              <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-end' }}>
+                {usageSummary.chartData.map((item) => (
+                  <UsageBar
+                    key={item.date}
+                    date={item.date}
+                    cost={item.cost}
+                    maxCost={usageSummary.maxCost}
+                  />
+                ))}
+              </Box>
+            )}
+          </Stack>
+        )}
       </Paper>
     </Box>
   );

--- a/webapp/packages/webui/src/services/userService.js
+++ b/webapp/packages/webui/src/services/userService.js
@@ -1,0 +1,30 @@
+// webapp/packages/webui/src/services/userService.js
+import apiClient from './apiClient';
+
+const userService = {
+  getProfile() {
+    return apiClient.get('/users/me');
+  },
+
+  updateMonthlyAllowance(monthlyAllowance) {
+    return apiClient.put('/users/me/monthly-allowance', { monthlyAllowance });
+  },
+
+  updateResetDate(allowanceResetDate) {
+    return apiClient.put('/users/me/allowance-reset-date', { allowanceResetDate });
+  },
+
+  resetAllowance() {
+    return apiClient.post('/users/me/reset-allowance');
+  },
+
+  updateSpendRemaining(spendRemaining) {
+    return apiClient.put('/users/me/spend-remaining', { spendRemaining });
+  },
+
+  addUsage(responseCost, metadata = null) {
+    return apiClient.post('/users/me/usage', { responseCost, metadata });
+  },
+};
+
+export default userService;


### PR DESCRIPTION
## Summary
- add persistent user model with allowance and usage tracking
- expose endpoints to manage allowances and usage data while enforcing spend checks around LLM calls
- display usage details and per-day response costs in the profile Usage tab

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e0a4dcf30832394c82f9a551bebb5)