### PR TITLE
Refactor user service for Firebase callable functions

### DIFF
--- a/webapp/packages/api/user-service/main.py
+++ b/webapp/packages/api/user-service/main.py
@@ -1,594 +1,520 @@
-# webapp/packages/api/user-service/main.py
-from fastapi import APIRouter, FastAPI, UploadFile, File, Depends, HTTPException, BackgroundTasks, Request, Header
-from fastapi.responses import JSONResponse
-from fastapi.middleware.cors import CORSMiddleware
-from typing import Annotated, Optional, Dict, Any, List
-from pydantic import BaseModel, Field
-from pydantic.config import ConfigDict
-from datetime import datetime
-import uuid
-import json
-import os
+"""Firebase-native user service endpoints implemented as callable functions."""
+from __future__ import annotations
+
 import traceback
-from pathlib import Path
-from contextlib import asynccontextmanager
+from datetime import datetime
+from typing import Any, Dict
+
+import firebase_admin
+from firebase_functions import https_fn, options as firebase_options
 
 from config import settings
 from config.routes_config import RouterConfig, resolve_router_configs
 from dependencies import (
+    _execute_agent_code,
     deploy_agent,
     fetch_spec_content,
     get_agent_deployment,
     get_available_providers,
-    get_db,
-    get_logger,
-    get_user_service_dep,
+    undeploy_agent,
     list_deployments as list_deployments_logic,
-    oauth2_scheme,
     process_chat,
     require_admin_access,
     run_deployed_agent as run_deployed_agent_logic,
-    undeploy_agent,
-    _execute_agent_code,
 )
 from models.agent import (
+    Agent,
+    CreateAgentRequest,
+    DeployedApi,
     GenerateCodeRequest,
     GenerateCodeResponse,
     RunCodeRequest,
     RunCodeResponse,
-    Agent,
-    CreateAgentRequest,
-    Deployment,
-    DeployedApi,
 )
-from models.demo import (
-    GenerateDemoCodeRequest,
-    GenerateDemoCodeResponse,
-    CreateDemoAppRequest,
-    DemoApp,
-)
+from models.chat import ChatRequest, ChatResponse, ProviderConfig
+from models.demo import CreateDemoAppRequest, DemoApp, GenerateDemoCodeRequest, GenerateDemoCodeResponse
 from models.user import User
-from services.database_service import DatabaseService
-from services.mcp_client_service import McpClientService, get_mcp_client_service
-from services.observability_service import (
-    get_observability_service,
-    get_sanitized_request_data,
-    ObservabilityMiddleware,
-    ObservabilityService,
-)
-from services.user_service import UserService
+from services.database_service import get_database_service
+from services.mcp_client_service import get_mcp_client_service
+from services.observability_service import ObservabilityService, get_observability_service, get_sanitized_request_data
+from services.user_service import get_user_service
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    """Application lifespan handler."""
-    logger = get_observability_service()
-    logger.log(
-        level="INFO",
-        event_type="lifecycle",
-        message="Application startup complete."
-    )
-    yield
+# Firebase initialization
+if not firebase_admin._apps:
+    firebase_admin.initialize_app()
+
+# Shared deployment options for all callable endpoints
+FUNCTION_DEPLOYMENT_OPTIONS = {
+    "cpu": 1,
+    "memory": firebase_options.MemoryOption.GB_1,
+    "timeout_sec": 540,
+}
 
 
-app = FastAPI(lifespan=lifespan)
-router = APIRouter()
+class ServiceContext:
+    """Container for services used by callable endpoints."""
 
-# Add observability middleware
-app.add_middleware(ObservabilityMiddleware)
+    def __init__(self) -> None:
+        self.db_service = get_database_service(settings)
+        self.user_service = get_user_service(self.db_service)
+        self.logger = get_observability_service()
+        self.mcp_client_service = get_mcp_client_service()
 
 
+SERVICE_CONTEXT = ServiceContext()
 
-frontend_url = os.getenv("FRONTEND_URL", "http://localhost:3000")
 
-allowed_origins = [frontend_url,]
-
-print(f"Configured allowed CORS origins: {allowed_origins}")
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"], #allowed_origins,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"], # For local/docker, "*" is fine for dev
-)
-
-# --- Security Dependency ---
-async def get_current_user(request: Request, token: str = Depends(oauth2_scheme)):
-    """
-    Dependency to verify Firebase ID token and get user info.
-    Attaches the user object to request.state for observability.
-    """
+def ensure_authenticated(request: https_fn.CallableRequest) -> Dict[str, Any]:
+    """Ensure the request is authenticated and return user info."""
     if settings.APP_ENV != "firebase":
-        # In non-firebase environments (like 'local'), skip authentication.
-        user = {"uid": "local-dev-user"}
-        request.state.user = user # Attach user to state
-        return user
+        return {"uid": "local-dev-user"}
 
-    if not token:
-        # Set a default anonymous user for observability before raising
-        request.state.user = {"uid": "anonymous"}
-        raise HTTPException(status_code=401, detail="Not authenticated")
+    if not request.auth:
+        raise https_fn.HttpsError(code=https_fn.FunctionsErrorCode.UNAUTHENTICATED, message="Not authenticated")
+
+    return request.auth
+
+
+def ensure_admin_access(request: https_fn.CallableRequest) -> None:
+    if settings.ADMIN_PANEL_ENABLED and request.auth:
+        claims = request.auth.get("token", {}) if isinstance(request.auth, dict) else {}
+        if claims.get("admin"):
+            return
     try:
-        decoded_token = auth.verify_id_token(token)
-        request.state.user = decoded_token # Attach user to state
-        return decoded_token
-    except auth.InvalidIdTokenError:
-        request.state.user = {"uid": "invalid-token"}
-        raise HTTPException(status_code=401, detail="Invalid authentication token")
-    except Exception as e:
-        request.state.user = {"uid": "auth-error"}
-        raise HTTPException(status_code=500, detail=f"Authentication error: {e}")
- 
-
-class ListMcpToolsRequest(BaseModel):
-    mcp_url: str
-    auth_token: Optional[str] = None
-
-class ClientLogPayload(BaseModel):
-    eventType: str
-    message: str
-    level: str = "INFO"
-    metadata: Optional[Dict[str, Any]] = None
-
-class FetchSpecRequest(BaseModel):
-    url: str
+        require_admin_access()
+    except Exception as exc:  # noqa: BLE001
+        raise https_fn.HttpsError(code=https_fn.FunctionsErrorCode.PERMISSION_DENIED, message=str(exc)) from exc
 
 
-class UpdateMonthlyAllowanceRequest(BaseModel):
-    monthly_allowance: float = Field(..., alias="monthlyAllowance")
-
-    model_config = ConfigDict(populate_by_name=True)
-
-
-class UpdateResetDateRequest(BaseModel):
-    allowance_reset_date: float = Field(..., alias="allowanceResetDate")
-
-    model_config = ConfigDict(populate_by_name=True)
-
-
-class UpdateSpendRemainingRequest(BaseModel):
-    spend_remaining: float = Field(..., alias="spendRemaining")
-
-    model_config = ConfigDict(populate_by_name=True)
+async def run_with_error_handling(coro):
+    try:
+        return await coro
+    except https_fn.HttpsError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        traceback.print_exc()
+        raise https_fn.HttpsError(
+            code=https_fn.FunctionsErrorCode.INTERNAL,
+            message=str(exc),
+        ) from exc
 
 
-class AddUsageRequest(BaseModel):
-    response_cost: float = Field(..., alias="responseCost")
-    metadata: Optional[Dict[str, Any]] = None
-
-    model_config = ConfigDict(populate_by_name=True)
-
-
-class AdminUpdateUserRequest(BaseModel):
-    monthly_allowance: Optional[float] = Field(default=None, alias="monthlyAllowance")
-    allowance_reset_date: Optional[float] = Field(default=None, alias="allowanceResetDate")
-    spend_remaining: Optional[float] = Field(default=None, alias="spendRemaining")
-
-    model_config = ConfigDict(populate_by_name=True)
-
-# Import models after defining local ones to avoid circular dependencies
-from models.chat import ChatRequest, ChatMessage, ChatResponse, ProviderConfig, SessionData
-
-
-# --- Routes ---
-@router.get("/")
-def read_root():
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def read_root(request: https_fn.CallableRequest) -> Dict[str, str]:
     return {"Hello": "World", "Service": "User-Service"}
 
-@router.post("/log/client", status_code=202)
-async def log_client_event(
-    payload: ClientLogPayload,
-    request: Request,
-    logger: ObservabilityService = Depends(get_logger)
-):
-    """Receives and logs an event from the frontend client."""
-    user_id = getattr(request.state, 'user', {}).get('uid', 'anonymous')
-    
-    # Add client-specific info to metadata
-    metadata = payload.metadata or {}
-    metadata['client_host'] = request.client.host if request.client else "unknown"
-    metadata['user_agent'] = request.headers.get("user-agent")
 
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+async def log_client_event(request: https_fn.CallableRequest) -> Dict[str, str]:
+    user = ensure_authenticated(request)
+    payload = request.data or {}
+    logger: ObservabilityService = SERVICE_CONTEXT.logger
+    metadata = payload.get("metadata") or {}
+    metadata.update({"user_agent": request.raw_request.headers.get("user-agent") if request.raw_request else None})
     logger.log(
-        event_type=payload.eventType,
-        message=payload.message,
-        level=payload.level,
-        service="webui",  # Explicitly set service to webui
-        user_id=user_id,
-        metadata=metadata
+        event_type=payload.get("eventType", "unknown"),
+        message=payload.get("message", ""),
+        level=payload.get("level", "INFO"),
+        service="webui",
+        user_id=user.get("uid", "anonymous"),
+        metadata=metadata,
     )
     return {"status": "logged"}
 
-@router.get("/providers")
-def get_providers():
-    """Get all available providers and their configurations"""
+
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def get_providers_callable(_: https_fn.CallableRequest):
     return get_available_providers()
 
-@router.get("/providers/{provider}")
-def get_provider_config_route(provider: str):
-    """Get configuration for a specific provider"""
-    available_providers = get_available_providers()
-    if provider not in available_providers:
-        raise HTTPException(status_code=404, detail="Provider not found or not configured")
-    return available_providers[provider]
 
-@router.get("/providers/{provider}/models")
-def get_provider_models(provider: str):
-    """Get available models for a provider"""
-    available_providers = get_available_providers()
-    if provider not in available_providers:
-        raise HTTPException(status_code=404, detail="Provider not found or not configured")
-    return list(available_providers[provider]["models"].keys())
-
-@router.get("/providers/{provider}/models/{model}")
-def get_model_config(provider: str, model: str):
-    """Get configuration for a specific model"""
-    available_providers = get_available_providers()
-    if provider not in available_providers:
-        raise HTTPException(status_code=404, detail="Provider not found or not configured")
-    if model not in available_providers[provider]["models"]:
-        raise HTTPException(status_code=404, detail="Model not found")
-    return available_providers[provider]["models"][model]
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def get_provider_config_callable(request: https_fn.CallableRequest):
+    provider = (request.data or {}).get("provider")
+    available = get_available_providers()
+    if provider not in available:
+        raise https_fn.HttpsError(code=https_fn.FunctionsErrorCode.NOT_FOUND, message="Provider not found or not configured")
+    return available[provider]
 
 
-@router.get("/users/me", response_model=User)
-def get_current_user_profile(user: dict = Depends(get_current_user), user_service: UserService = Depends(get_user_service_dep)):
-    return user_service.get_user(user.get("uid", "anonymous"), user)
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def get_provider_models_callable(request: https_fn.CallableRequest):
+    provider = (request.data or {}).get("provider")
+    available = get_available_providers()
+    if provider not in available:
+        raise https_fn.HttpsError(code=https_fn.FunctionsErrorCode.NOT_FOUND, message="Provider not found or not configured")
+    return list(available[provider]["models"].keys())
 
 
-@router.get("/admin/users", response_model=List[User])
-def list_all_users(
-    user_service: UserService = Depends(get_user_service_dep),
-    _: None = Depends(require_admin_access),
-):
-    return user_service.list_users()
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def get_model_config_callable(request: https_fn.CallableRequest):
+    provider = (request.data or {}).get("provider")
+    model = (request.data or {}).get("model")
+    available = get_available_providers()
+    if provider not in available or model not in available[provider]["models"]:
+        raise https_fn.HttpsError(code=https_fn.FunctionsErrorCode.NOT_FOUND, message="Provider or model not found")
+    return available[provider]["models"][model]
 
 
-@router.put("/admin/users/{user_id}", response_model=User)
-def update_user_allowances(
-    user_id: str,
-    request: AdminUpdateUserRequest,
-    user_service: UserService = Depends(get_user_service_dep),
-    _: None = Depends(require_admin_access),
-):
-    return user_service.update_user_usage_info(
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def get_current_user_profile_callable(request: https_fn.CallableRequest) -> User:
+    user = ensure_authenticated(request)
+    return SERVICE_CONTEXT.user_service.get_user(user.get("uid", "anonymous"), user)
+
+
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def list_all_users_callable(request: https_fn.CallableRequest):
+    ensure_admin_access(request)
+    return SERVICE_CONTEXT.user_service.list_users()
+
+
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def update_user_allowances_callable(request: https_fn.CallableRequest):
+    ensure_admin_access(request)
+    data = request.data or {}
+    user_id = data.get("userId")
+    return SERVICE_CONTEXT.user_service.update_user_usage_info(
         user_id,
-        monthly_allowance=request.monthly_allowance,
-        allowance_reset_date=request.allowance_reset_date,
-        spend_remaining=request.spend_remaining,
+        monthly_allowance=data.get("monthlyAllowance"),
+        allowance_reset_date=data.get("allowanceResetDate"),
+        spend_remaining=data.get("spendRemaining"),
     )
 
 
-@router.put("/users/me/monthly-allowance", response_model=User)
-def set_monthly_allowance(
-    request: UpdateMonthlyAllowanceRequest,
-    user: dict = Depends(get_current_user),
-    user_service: UserService = Depends(get_user_service_dep),
-):
-    return user_service.set_monthly_allowance(user.get("uid", "anonymous"), request.monthly_allowance, user)
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def set_monthly_allowance_callable(request: https_fn.CallableRequest):
+    user = ensure_authenticated(request)
+    data = request.data or {}
+    return SERVICE_CONTEXT.user_service.set_monthly_allowance(user.get("uid", "anonymous"), data.get("monthlyAllowance"), user)
 
 
-@router.put("/users/me/allowance-reset-date", response_model=User)
-def set_allowance_reset_date(
-    request: UpdateResetDateRequest,
-    user: dict = Depends(get_current_user),
-    user_service: UserService = Depends(get_user_service_dep),
-):
-    return user_service.set_reset_date(user.get("uid", "anonymous"), request.allowance_reset_date, user)
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def set_allowance_reset_date_callable(request: https_fn.CallableRequest):
+    user = ensure_authenticated(request)
+    data = request.data or {}
+    return SERVICE_CONTEXT.user_service.set_reset_date(user.get("uid", "anonymous"), data.get("allowanceResetDate"), user)
 
 
-@router.post("/users/me/reset-allowance", response_model=User)
-def reset_allowance(user: dict = Depends(get_current_user), user_service: UserService = Depends(get_user_service_dep)):
-    return user_service.reset_allowance(user.get("uid", "anonymous"), user)
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def reset_allowance_callable(request: https_fn.CallableRequest):
+    user = ensure_authenticated(request)
+    return SERVICE_CONTEXT.user_service.reset_allowance(user.get("uid", "anonymous"), user)
 
 
-@router.put("/users/me/spend-remaining", response_model=User)
-def update_spend_remaining(
-    request: UpdateSpendRemainingRequest,
-    user: dict = Depends(get_current_user),
-    user_service: UserService = Depends(get_user_service_dep),
-):
-    return user_service.update_spend_remaining(user.get("uid", "anonymous"), request.spend_remaining, user)
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def update_spend_remaining_callable(request: https_fn.CallableRequest):
+    user = ensure_authenticated(request)
+    data = request.data or {}
+    return SERVICE_CONTEXT.user_service.update_spend_remaining(user.get("uid", "anonymous"), data.get("spendRemaining"), user)
 
 
-@router.post("/users/me/usage", response_model=User)
-def add_usage_entry(
-    request: AddUsageRequest,
-    user: dict = Depends(get_current_user),
-    user_service: UserService = Depends(get_user_service_dep),
-):
-    return user_service.add_usage(user.get("uid", "anonymous"), request.response_cost, request.metadata, user)
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def add_usage_entry_callable(request: https_fn.CallableRequest):
+    user = ensure_authenticated(request)
+    data = request.data or {}
+    return SERVICE_CONTEXT.user_service.add_usage(
+        user.get("uid", "anonymous"),
+        data.get("responseCost"),
+        data.get("metadata"),
+        user,
+    )
 
-@router.post("/chat")
-async def chat(request: ChatRequest, req: Request, background_tasks: BackgroundTasks, user: dict = Depends(get_current_user)):
-    """Submit a chat request and get a ticket ID"""
-    ticket_id = str(uuid.uuid4())
-    
-    # Start processing in background, passing user context
-    background_tasks.add_task(process_chat, ticket_id, request, user, req)
-    
+
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+async def chat_callable(request: https_fn.CallableRequest):
+    user = ensure_authenticated(request)
+    chat_request = ChatRequest(**(request.data or {}))
+    ticket_id = chat_request.ticket_id or ""
+    if not ticket_id:
+        ticket_id = chat_request.dict().get("ticket_id") or chat_request.dict(by_alias=True).get("ticket_id") or ""
+    if not ticket_id:
+        ticket_id = str(datetime.utcnow().timestamp()).replace(".", "-")
+
+    await run_with_error_handling(process_chat(ticket_id, chat_request, user, request.raw_request))
+    return ChatResponse(ticket_id=ticket_id, status="pending").dict()
+
+
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def get_chat_status_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    data = request.data or {}
+    ticket_id = data.get("ticketId")
+    db = SERVICE_CONTEXT.db_service
+    ticket_data = db.get("tickets", ticket_id)
     return ChatResponse(
-        ticket_id=ticket_id,
-        status="pending"
-    )
+        ticket_id=ticket_data.get("_id", ticket_id),
+        status=ticket_data["status"],
+        result=ticket_data.get("result"),
+        error=ticket_data.get("error"),
+    ).dict()
 
-@router.get("/chat/{ticket_id}")
-async def get_chat_status(ticket_id: str, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
-    """Get the status and result of a chat request"""
-    try:
-        ticket_data = db.get("tickets", ticket_id)
-        return ChatResponse(
-            ticket_id=ticket_data.get("_id", ticket_id),
-            status=ticket_data["status"],
-            result=ticket_data.get("result"),
-            error=ticket_data.get("error")
-        )
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
 
-@router.post("/sessions/{session_id}/config")
-async def update_session_config(session_id: str, config: ProviderConfig, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
-    """Update session configuration"""
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def update_session_config_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    data = request.data or {}
+    session_id = data.get("sessionId")
+    config = ProviderConfig(**data.get("config", {}))
+    db = SERVICE_CONTEXT.db_service
     try:
         session_doc = db.get("sessions", session_id)
-    except HTTPException as e:
-        if e.status_code == 404:
-            session_doc = {"created_at": datetime.utcnow().isoformat()}
-        else:
-            raise
-
+    except Exception:
+        session_doc = {"created_at": datetime.utcnow().isoformat()}
     session_doc["provider_config"] = config.dict()
     session_doc["updated_at"] = datetime.utcnow().isoformat()
-    
     db.save("sessions", session_id, session_doc)
     return {"message": "Configuration updated", "session_id": session_id}
 
-@router.get("/sessions/{session_id}/config")
-async def get_session_config(session_id: str, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
-    """Get session configuration"""
-    session_doc = db.get("sessions", session_id)
+
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def get_session_config_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    session_id = (request.data or {}).get("sessionId")
+    session_doc = SERVICE_CONTEXT.db_service.get("sessions", session_id)
     return session_doc.get("provider_config")
 
-@router.delete("/sessions/{session_id}")
-async def delete_session(session_id: str, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
-    """Delete a session"""
-    db.delete("sessions", session_id)
+
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def delete_session_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    session_id = (request.data or {}).get("sessionId")
+    SERVICE_CONTEXT.db_service.delete("sessions", session_id)
     return {"message": "Session deleted"}
 
-# Health check
-@router.get("/health")
-def health_check():
+
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def health_check_callable(_: https_fn.CallableRequest):
     return {"status": "healthy", "service": "user-service"}
 
 
-@router.post("/agents", response_model=Agent, status_code=201)
-async def create_agent(
-    request: CreateAgentRequest,
-    req: Request,
-    db: DatabaseService = Depends(get_db),
-    user: dict = Depends(get_current_user),
-    logger: ObservabilityService = Depends(get_logger)
-):
-    """Saves a new agent configuration to the database."""
-    agent_data_internal_names = request.model_dump(by_alias=True)
-    agent = Agent(**agent_data_internal_names)
-
-    # Save the agent to the database.
-    # Use by_alias=True to serialize the Agent model into a dictionary
-    # with camelCase keys (e.g., inputSchema, swaggerSpecs, _id, _rev)
-    # matching the common external representation and CouchDB's _id/_rev.
-    saved_doc_data = agent.model_dump(by_alias=True, mode="json")
-    saved_doc = db.save("agents", agent.id, saved_doc_data)
-    
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+async def create_agent_callable(request: https_fn.CallableRequest):
+    user = ensure_authenticated(request)
+    req = CreateAgentRequest(**(request.data or {}))
+    db = SERVICE_CONTEXT.db_service
+    logger = SERVICE_CONTEXT.logger
+    agent = Agent(**req.model_dump(by_alias=True))
+    saved_doc = db.save("agents", agent.id, agent.model_dump(by_alias=True, mode="json"))
     agent.rev = saved_doc.get("rev")
-    
     logger.log(
-        "INFO", "user_action", f"Agent '{agent.name}' created.",
-        metadata={"agent_id": agent.id, "agent_name": agent.name, "request": get_sanitized_request_data(req)}
+        "INFO",
+        "user_action",
+        f"Agent '{agent.name}' created.",
+        metadata={"agent_id": agent.id, "agent_name": agent.name, "request": get_sanitized_request_data(request.raw_request)},
     )
-    return agent
-
-@router.get("/agents", response_model=List[Agent])
-async def list_agents(
-    req: Request,
-    db: DatabaseService = Depends(get_db),
-    user: dict = Depends(get_current_user),
-    logger: ObservabilityService = Depends(get_logger)
-):
-    """Lists all saved agents."""
-    all_docs = db.list_all("agents")
-    logger.log("INFO", "user_action", "Listed all agents.", metadata={"request": get_sanitized_request_data(req)})
-    return [Agent(**doc) for doc in all_docs]
-
-@router.get("/agents/{agent_id}", response_model=Agent)
-async def get_agent(agent_id: str, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
-    """Retrieves a specific agent by its ID."""
-    agent_doc = db.get("agents", agent_id)
-    return Agent(**agent_doc)
-
-@router.delete("/agents/{agent_id}", status_code=204)
-async def delete_agent(
-    agent_id: str, 
-    req: Request,
-    db: DatabaseService = Depends(get_db), 
-    user: dict = Depends(get_current_user),
-    logger: ObservabilityService = Depends(get_logger)
-):
-    """Deletes an agent by its ID."""
-    try:
-        db.delete("agents", agent_id)
-        logger.log("INFO", "user_action", f"Agent '{agent_id}' deleted.", metadata={"agent_id": agent_id, "request": get_sanitized_request_data(req)})
-        return
-    except HTTPException as e:
-        raise e
+    return agent.model_dump()
 
 
-@router.post("/mcp/tools")
-async def list_mcp_tools(
-    request: ListMcpToolsRequest,
-    mcp_service: McpClientService = Depends(get_mcp_client_service),
-    user: dict = Depends(get_current_user)
-):
-    """Connects to a remote MCP server and lists its available tools."""
-    tools = await mcp_service.list_tools_for_server(request.mcp_url, request.auth_token)
-    return {"mcp_url": request.mcp_url, "tools": tools}
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+async def list_agents_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    db = SERVICE_CONTEXT.db_service
+    agents = [Agent(**doc).model_dump() for doc in db.list_all("agents")]
+    SERVICE_CONTEXT.logger.log("INFO", "user_action", "Listed all agents.", metadata={"request": get_sanitized_request_data(request.raw_request)})
+    return agents
 
-@router.post("/agents/generate-code", response_model=GenerateCodeResponse)
-async def generate_agent_code(request: GenerateCodeRequest, user: dict = Depends(get_current_user)):
-    """Generates agent code based on the provided configuration."""
+
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def get_agent_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    agent_id = (request.data or {}).get("agentId")
+    agent_doc = SERVICE_CONTEXT.db_service.get("agents", agent_id)
+    return Agent(**agent_doc).model_dump()
+
+
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def delete_agent_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    agent_id = (request.data or {}).get("agentId")
+    SERVICE_CONTEXT.db_service.delete("agents", agent_id)
+    SERVICE_CONTEXT.logger.log("INFO", "user_action", f"Agent '{agent_id}' deleted.", metadata={"agent_id": agent_id, "request": get_sanitized_request_data(request.raw_request)})
+    return {"status": "deleted"}
+
+
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+async def list_mcp_tools_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    data = request.data or {}
+    tools = await SERVICE_CONTEXT.mcp_client_service.list_tools_for_server(data.get("mcp_url"), data.get("auth_token"))
+    return {"mcp_url": data.get("mcp_url"), "tools": tools}
+
+
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+async def generate_agent_code_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    req = GenerateCodeRequest(**(request.data or {}))
     from agent_factory import generate_agent_code as generate_code_function
-    code = await generate_code_function(request)
-    return code
 
-@router.post("/specs/fetch")
-async def fetch_spec_from_url(request: FetchSpecRequest, user: dict = Depends(get_current_user)):
-    """Fetches OpenAPI/Swagger spec content from a public URL."""
-    return await fetch_spec_content(request.url)
+    code = await generate_code_function(req)
+    return GenerateCodeResponse(**code.model_dump()).model_dump()
 
 
-@router.post("/agents/{agent_id}/deploy", status_code=201)
-async def deploy_agent_route(agent_id: str, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
-    """Registers an agent for internal REST deployment."""
-    return await deploy_agent(agent_id, db)
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+async def fetch_spec_from_url_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    data = request.data or {}
+    return await fetch_spec_content(data.get("url"))
 
-@router.delete("/agents/{agent_id}/undeploy", status_code=204)
-async def undeploy_agent_route(agent_id: str, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
-    """Removes an agent from the internal REST deployment registry."""
-    await undeploy_agent(agent_id, db)
-    return
 
-@router.get("/agents/{agent_id}/deployment")
-async def get_agent_deployment_route(agent_id: str, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
-    """Checks if an agent is deployed and returns its public-facing name."""
-    return await get_agent_deployment(agent_id, db)
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+async def deploy_agent_route_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    agent_id = (request.data or {}).get("agentId")
+    return await deploy_agent(agent_id, SERVICE_CONTEXT.db_service)
 
-@router.get("/deployments", response_model=List[DeployedApi])
-async def list_deployments_route(db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
-    """Lists all deployed agents/APIs with their relevant details."""
-    deployments = await list_deployments_logic(db)
-    return [DeployedApi(**dep) for dep in deployments]
 
-@router.post("/agents/run-code", response_model=RunCodeResponse)
-async def run_agent_code(
-    request: RunCodeRequest,
-    req: Request,
-    user: dict = Depends(get_current_user),
-    db: DatabaseService = Depends(get_db),
-    logger: ObservabilityService = Depends(get_logger)
-):
-    """Executes agent code in a sandboxed environment."""
-    logger.log("INFO", "user_action", "Attempting to run agent code in sandbox.", metadata={"request": get_sanitized_request_data(req)})
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+async def undeploy_agent_route_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    agent_id = (request.data or {}).get("agentId")
+    await undeploy_agent(agent_id, SERVICE_CONTEXT.db_service)
+    return {"status": "undeployed"}
+
+
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+async def get_agent_deployment_route_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    agent_id = (request.data or {}).get("agentId")
+    return await get_agent_deployment(agent_id, SERVICE_CONTEXT.db_service)
+
+
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+async def list_deployments_route_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    deployments = await list_deployments_logic(SERVICE_CONTEXT.db_service)
+    return [DeployedApi(**dep).model_dump() for dep in deployments]
+
+
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+async def run_agent_code_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    req = RunCodeRequest(**(request.data or {}))
+    logger = SERVICE_CONTEXT.logger
+    logger.log("INFO", "user_action", "Attempting to run agent code in sandbox.", metadata={"request": get_sanitized_request_data(request.raw_request)})
     try:
         result = await _execute_agent_code(
-            code=request.code,
-            input_dict=request.input_dict,
-            tools=request.tools,
-            gofannon_agents=request.gofannon_agents,
-            db=db
+            code=req.code,
+            input_dict=req.input_dict,
+            tools=req.tools,
+            gofannon_agents=req.gofannon_agents,
+            db=SERVICE_CONTEXT.db_service,
         )
-
-        logger.log("INFO", "sandbox_run", "Agent code executed successfully.", metadata={"request": get_sanitized_request_data(req)})
-        return RunCodeResponse(result=result)
-        
-    except Exception as e:
-        error_str = f"{type(e).__name__}: {e}"
+        logger.log("INFO", "sandbox_run", "Agent code executed successfully.", metadata={"request": get_sanitized_request_data(request.raw_request)})
+        return RunCodeResponse(result=result).model_dump()
+    except Exception as exc:  # noqa: BLE001
         tb_str = traceback.format_exc()
-        
-        logger.log(
-            "ERROR", "sandbox_run_failure", f"Error running agent code: {error_str}", 
-            metadata={"traceback": tb_str, "request": get_sanitized_request_data(req)}
-        )
-        
-        # The ObservabilityMiddleware will catch this and return a 500 response.
-        # We re-raise it here so that middleware can do its job.
-        raise e
+        logger.log("ERROR", "sandbox_run_failure", f"Error running agent code: {exc}", metadata={"traceback": tb_str, "request": get_sanitized_request_data(request.raw_request)})
+        raise https_fn.HttpsError(code=https_fn.FunctionsErrorCode.INTERNAL, message=str(exc)) from exc
 
-@router.post("/rest/{friendly_name}")
-async def run_deployed_agent_route(friendly_name: str, request: Request, db: DatabaseService = Depends(get_db)):
-    """Public endpoint to run a deployed agent by its friendly_name."""
-    input_dict = await request.json()
-    return await run_deployed_agent_logic(friendly_name, input_dict, db)
 
-# --- Demo App Endpoints ---
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+async def run_deployed_agent_route_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    data = request.data or {}
+    friendly_name = data.get("friendlyName")
+    input_dict = data.get("input", {})
+    return await run_deployed_agent_logic(friendly_name, input_dict, SERVICE_CONTEXT.db_service)
 
-@router.post("/demos/generate-code", response_model=GenerateDemoCodeResponse)
-async def generate_demo_app_code(request: GenerateDemoCodeRequest, user: dict = Depends(get_current_user)):
-    """
-    Generates HTML/CSS/JS for a demo app based on a prompt and selected APIs.
-    """
+
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+async def generate_demo_app_code_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    req = GenerateDemoCodeRequest(**(request.data or {}))
     from agent_factory.demo_factory import generate_demo_code
+
     try:
-        code_response = await generate_demo_code(request)
-        return code_response
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error generating demo code: {e}")
+        code_response = await generate_demo_code(req)
+        return code_response.model_dump()
+    except Exception as exc:  # noqa: BLE001
+        raise https_fn.HttpsError(code=https_fn.FunctionsErrorCode.INTERNAL, message=f"Error generating demo code: {exc}") from exc
 
-@router.post("/demos", response_model=DemoApp, status_code=201)
-async def create_demo_app(request: CreateDemoAppRequest, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
-    """Saves a new demo app configuration."""
-    demo_app_data = request.model_dump(by_alias=True)
-    demo_app = DemoApp(**demo_app_data)
-    saved_doc_data = demo_app.model_dump(by_alias=True, mode="json")
-    saved_doc = db.save("demos", demo_app.id, saved_doc_data)
+
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+async def create_demo_app_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    req = CreateDemoAppRequest(**(request.data or {}))
+    db = SERVICE_CONTEXT.db_service
+    demo_app = DemoApp(**req.model_dump(by_alias=True))
+    saved_doc = db.save("demos", demo_app.id, demo_app.model_dump(by_alias=True, mode="json"))
     demo_app.rev = saved_doc.get("rev")
-    return demo_app
+    return demo_app.model_dump()
 
-@router.get("/demos", response_model=List[DemoApp])
-async def list_demo_apps(db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
-    """Lists all saved demo apps."""
-    all_docs = db.list_all("demos")
-    return [DemoApp(**doc) for doc in all_docs]
 
-@router.get("/demos/{demo_id}", response_model=DemoApp)
-async def get_demo_app(demo_id: str, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
-    """Retrieves a specific demo app."""
-    doc = db.get("demos", demo_id)
-    return DemoApp(**doc)
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+async def list_demo_apps_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    return [DemoApp(**doc).model_dump() for doc in SERVICE_CONTEXT.db_service.list_all("demos")]
 
-@router.put("/demos/{demo_id}", response_model=DemoApp)
-async def update_demo_app(demo_id: str, request: CreateDemoAppRequest, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
-    """Updates an existing demo app."""
-    demo_app_data = request.model_dump(by_alias=True)
-    updated_model = DemoApp(_id=demo_id, **demo_app_data)
-    saved_doc_data = updated_model.model_dump(by_alias=True, mode="json")
-    saved_doc = db.save("demos", demo_id, saved_doc_data)
+
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def get_demo_app_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    demo_id = (request.data or {}).get("demoId")
+    doc = SERVICE_CONTEXT.db_service.get("demos", demo_id)
+    return DemoApp(**doc).model_dump()
+
+
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+async def update_demo_app_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    data = request.data or {}
+    demo_id = data.get("demoId")
+    req = CreateDemoAppRequest(**data)
+    db = SERVICE_CONTEXT.db_service
+    updated_model = DemoApp(_id=demo_id, **req.model_dump(by_alias=True))
+    saved_doc = db.save("demos", demo_id, updated_model.model_dump(by_alias=True, mode="json"))
     updated_model.rev = saved_doc.get("rev")
-    return updated_model
+    return updated_model.model_dump()
 
-@router.delete("/demos/{demo_id}", status_code=204)
-async def delete_demo_app(demo_id: str, db: DatabaseService = Depends(get_db), user: dict = Depends(get_current_user)):
-    """Deletes a demo app."""
-    db.delete("demos", demo_id)
-    return
 
-# Apply router configuration to the FastAPI app, allowing extensions to provide routers.
-for router_config in resolve_router_configs([RouterConfig(router=router)]):
-    app.include_router(router_config.router, prefix=router_config.prefix, tags=router_config.tags or [])
+@https_fn.on_call(**FUNCTION_DEPLOYMENT_OPTIONS)
+def delete_demo_app_callable(request: https_fn.CallableRequest):
+    ensure_authenticated(request)
+    demo_id = (request.data or {}).get("demoId")
+    SERVICE_CONTEXT.db_service.delete("demos", demo_id)
+    return {"status": "deleted"}
 
-# This is an unseemly hack to adapt FastAPI to Google Cloud Functions.
-# TODO refactor all of this into microservices.
-from a2wsgi import ASGIMiddleware
 
-wsgi_app = ASGIMiddleware(app)
-
-ALLOWED_METHODS = "GET,POST,PUT,PATCH,DELETE,OPTIONS"
-ALLOWED_HEADERS_FALLBACK = "authorization,content-type"
-MAX_AGE = "3600"
-
-def build_cors_headers(req, *, origin_override=None):
-    origin = origin_override or req.headers.get("origin") or frontend_url or "*"
-    req_headers = req.headers.get("access-control-request-headers", "")
-    return {
-        "access-control-allow-origin": origin,
-        "access-control-allow-methods": ALLOWED_METHODS,
-        "access-control-allow-headers": req_headers or ALLOWED_HEADERS_FALLBACK,
-        "access-control-max-age": MAX_AGE,
-        # Vary ensures proper caching when Origin / ACR* differ
-        "vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
-        # Uncomment if you use cookies/Authorization with browsers:
-        # "access-control-allow-credentials": "true",
-    }
-
+# Apply router configuration hooks (for compatibility with existing extension points)
+RESOLVED_ROUTERS = resolve_router_configs([RouterConfig(router=None)])
+__all__ = [
+    "read_root",
+    "log_client_event",
+    "get_providers_callable",
+    "get_provider_config_callable",
+    "get_provider_models_callable",
+    "get_model_config_callable",
+    "get_current_user_profile_callable",
+    "list_all_users_callable",
+    "update_user_allowances_callable",
+    "set_monthly_allowance_callable",
+    "set_allowance_reset_date_callable",
+    "reset_allowance_callable",
+    "update_spend_remaining_callable",
+    "add_usage_entry_callable",
+    "chat_callable",
+    "get_chat_status_callable",
+    "update_session_config_callable",
+    "get_session_config_callable",
+    "delete_session_callable",
+    "health_check_callable",
+    "create_agent_callable",
+    "list_agents_callable",
+    "get_agent_callable",
+    "delete_agent_callable",
+    "list_mcp_tools_callable",
+    "generate_agent_code_callable",
+    "fetch_spec_from_url_callable",
+    "deploy_agent_route_callable",
+    "undeploy_agent_route_callable",
+    "get_agent_deployment_route_callable",
+    "list_deployments_route_callable",
+    "run_agent_code_callable",
+    "run_deployed_agent_route_callable",
+    "generate_demo_app_code_callable",
+    "create_demo_app_callable",
+    "list_demo_apps_callable",
+    "get_demo_app_callable",
+    "update_demo_app_callable",
+    "delete_demo_app_callable",
+]


### PR DESCRIPTION
## Summary
- replace the FastAPI-based user service with Firebase callable HTTPS functions for each route
- initialize shared services through a reusable ServiceContext and enforce authentication within callables
- set explicit CPU, memory, and timeout options on all callable endpoints

## Testing
- python -m compileall webapp/packages/api/user-service/main.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f413f02ac8323b21f949de2ef4a1b)