### PR TITLE
Add unit tests for app factory and routes config

### DIFF
--- a/webapp/packages/api/user-service/tests/unit/test_app_factory.py
+++ b/webapp/packages/api/user-service/tests/unit/test_app_factory.py
@@ -1,0 +1,52 @@
+"""Unit tests for app factory helpers."""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from app_factory import _configure_cors, create_app
+from services.observability_service import ObservabilityMiddleware
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_create_app_includes_router_and_observability(monkeypatch):
+    dummy_router = APIRouter(prefix="/dummy")
+
+    @dummy_router.get("/ping")
+    def _ping():
+        return {"ok": True}
+
+    dummy_module = types.ModuleType("routes")
+    dummy_module.router = dummy_router
+    monkeypatch.setitem(sys.modules, "routes", dummy_module)
+
+    app = create_app()
+
+    route_paths = {route.path for route in app.router.routes}
+    assert "/dummy/ping" in route_paths
+    assert any(middleware.cls is ObservabilityMiddleware for middleware in app.user_middleware)
+
+
+def test_configure_cors_adds_middleware():
+    app = FastAPI()
+
+    _configure_cors(app)
+
+    cors_middleware = [
+        middleware
+        for middleware in app.user_middleware
+        if middleware.cls is CORSMiddleware
+    ]
+    assert cors_middleware, "Expected CORSMiddleware to be configured"
+
+    cors_options = cors_middleware[0].options
+    assert cors_options["allow_origins"] == ["*"]
+    assert cors_options["allow_methods"] == ["*"]
+    assert cors_options["allow_headers"] == ["*"]
+    assert cors_options["allow_credentials"] is True

--- a/webapp/packages/api/user-service/tests/unit/test_routes_config.py
+++ b/webapp/packages/api/user-service/tests/unit/test_routes_config.py
@@ -1,0 +1,37 @@
+"""Unit tests for route configuration resolution."""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+from fastapi import APIRouter
+
+from config.routes_config import RouterConfig, resolve_router_configs
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_resolve_router_configs_returns_defaults_when_unset(monkeypatch):
+    monkeypatch.delenv("APP_ROUTER_CONFIG", raising=False)
+    default_router = APIRouter()
+    default_config = RouterConfig(router=default_router, prefix="/default")
+
+    resolved = resolve_router_configs([default_config])
+
+    assert resolved == [default_config]
+
+
+def test_resolve_router_configs_ignores_empty_configs(monkeypatch):
+    default_router = APIRouter()
+    default_config = RouterConfig(router=default_router, prefix="/default")
+
+    dummy_module = types.ModuleType("empty_router_config")
+    dummy_module.ROUTER_CONFIGS = []
+    monkeypatch.setitem(sys.modules, "empty_router_config", dummy_module)
+    monkeypatch.setenv("APP_ROUTER_CONFIG", "empty_router_config")
+
+    resolved = resolve_router_configs([default_config])
+
+    assert resolved == [default_config]


### PR DESCRIPTION
### Motivation
- Add unit tests to validate router configuration loading behavior in `resolve_router_configs` including default handling and ignoring empty overrides.
- Ensure `create_app` wires up the API router and attaches observability via `ObservabilityMiddleware`.
- Verify that CORS configuration is applied by `_configure_cors` and exposes the expected middleware options.

### Description
- Added `tests/unit/test_routes_config.py` with tests that assert `resolve_router_configs` returns provided defaults when `APP_ROUTER_CONFIG` is unset and ignores empty `ROUTER_CONFIGS` modules.
- Added `tests/unit/test_app_factory.py` with tests that monkeypatch a `routes` module to include a small dummy `APIRouter` and assert `create_app` exposes the expected route and includes `ObservabilityMiddleware` in `app.user_middleware`.
- The CORS test calls `_configure_cors` and asserts a `CORSMiddleware` entry exists and its `options` include `allow_origins`, `allow_methods`, `allow_headers`, and `allow_credentials` as expected.

### Testing
- No automated test suite was executed as part of this change; the new unit tests were added but not run.
- The new test files are `webapp/packages/api/user-service/tests/unit/test_app_factory.py` and `webapp/packages/api/user-service/tests/unit/test_routes_config.py` and were committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eb7ad7b10832391288e44f40b7f31)