### PR TITLE
Add unit tests for LLM, storage and in-memory DB services

### DIFF
--- a/webapp/packages/api/user-service/tests/unit/services/test_llm_service.py
+++ b/webapp/packages/api/user-service/tests/unit/services/test_llm_service.py
@@ -1,0 +1,78 @@
+"""Unit tests for LLM service."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from services import llm_service
+
+
+pytestmark = pytest.mark.unit
+
+
+class _DummyMessage:
+    def __init__(self, content: str):
+        self.content = content
+        self.tool_calls = None
+
+
+class _DummyChoice:
+    def __init__(self, message):
+        self.message = message
+
+
+class _DummyResponse:
+    def __init__(self, content: str, total_cost: float = 0.0):
+        self.choices = [_DummyChoice(_DummyMessage(content))]
+        self.usage = SimpleNamespace(total_cost=total_cost)
+
+
+@pytest.mark.asyncio
+async def test_call_llm_acompletion_success(monkeypatch):
+    async def fake_acompletion(**_kwargs):
+        return _DummyResponse("hello", total_cost=1.23)
+
+    monkeypatch.setattr(llm_service.litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(llm_service, "get_observability_service", lambda: Mock())
+
+    user_service = Mock()
+
+    content, thoughts = await llm_service.call_llm(
+        provider="openai",
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        parameters={},
+        user_service=user_service,
+        user_id="user-1",
+    )
+
+    assert content == "hello"
+    assert thoughts is None
+    user_service.require_allowance.assert_called_once_with("user-1", basic_info=None)
+    user_service.add_usage.assert_called_once_with("user-1", 1.23, basic_info=None)
+
+
+@pytest.mark.asyncio
+async def test_call_llm_acompletion_error(monkeypatch):
+    async def fake_acompletion(**_kwargs):
+        raise RuntimeError("boom")
+
+    observability = Mock()
+    monkeypatch.setattr(llm_service.litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(llm_service, "get_observability_service", lambda: observability)
+
+    user_service = Mock()
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await llm_service.call_llm(
+            provider="openai",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            parameters={},
+            user_service=user_service,
+            user_id="user-2",
+        )
+
+    observability.log_exception.assert_called_once()

--- a/webapp/packages/api/user-service/tests/unit/services/test_memory_database_service.py
+++ b/webapp/packages/api/user-service/tests/unit/services/test_memory_database_service.py
@@ -1,0 +1,44 @@
+"""Unit tests for in-memory database service."""
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from services.database_service.memory import MemoryDBService
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_memory_db_crud_flow():
+    service = MemoryDBService()
+
+    result = service.save("agents", "agent-1", {"name": "agent"})
+
+    assert result == {"id": "agent-1", "rev": "memory-rev"}
+    assert service.get("agents", "agent-1") == {"name": "agent"}
+    assert service.list_all("agents") == [{"name": "agent"}]
+
+    service.delete("agents", "agent-1")
+
+    assert service.list_all("agents") == []
+
+
+def test_memory_db_missing_get_raises():
+    service = MemoryDBService()
+
+    with pytest.raises(HTTPException) as exc_info:
+        service.get("agents", "missing")
+
+    assert exc_info.value.status_code == 404
+    assert "missing" in exc_info.value.detail
+
+
+def test_memory_db_missing_delete_raises():
+    service = MemoryDBService()
+
+    with pytest.raises(HTTPException) as exc_info:
+        service.delete("agents", "missing")
+
+    assert exc_info.value.status_code == 404
+    assert "missing" in exc_info.value.detail

--- a/webapp/packages/api/user-service/tests/unit/services/test_storage_service.py
+++ b/webapp/packages/api/user-service/tests/unit/services/test_storage_service.py
@@ -1,0 +1,71 @@
+"""Unit tests for storage services."""
+from __future__ import annotations
+
+import io
+from unittest.mock import Mock
+
+import pytest
+
+from services import storage_service
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_s3_storage_upload_and_url(monkeypatch):
+    uploaded = {}
+
+    class FakeClient:
+        def upload_fileobj(self, file_obj, bucket, file_name):
+            uploaded["bucket"] = bucket
+            uploaded["file_name"] = file_name
+            uploaded["content"] = file_obj.read()
+
+    monkeypatch.setattr(storage_service.boto3, "client", lambda *args, **kwargs: FakeClient())
+    monkeypatch.setattr(storage_service.settings, "S3_ENDPOINT_URL", "http://s3")
+    monkeypatch.setattr(storage_service.settings, "S3_BUCKET_NAME", "bucket")
+    monkeypatch.setattr(storage_service.settings, "AWS_ACCESS_KEY_ID", "key")
+    monkeypatch.setattr(storage_service.settings, "AWS_SECRET_ACCESS_KEY", "secret")
+    monkeypatch.setattr(storage_service.settings, "AWS_DEFAULT_REGION", "us-east-1")
+
+    service = storage_service.S3StorageService()
+    payload = io.BytesIO(b"hello")
+
+    service.upload("file.txt", payload)
+
+    assert uploaded == {"bucket": "bucket", "file_name": "file.txt", "content": b"hello"}
+    assert service.get_public_url("file.txt") == "http://s3/bucket/file.txt"
+
+
+def test_gcs_storage_upload_and_url(monkeypatch):
+    uploaded = {}
+
+    class FakeBlob:
+        def __init__(self, name):
+            self.name = name
+
+        def upload_from_file(self, file_obj):
+            uploaded["name"] = self.name
+            uploaded["content"] = file_obj.read()
+
+    class FakeBucket:
+        def __init__(self, name):
+            self.name = name
+
+        def blob(self, name):
+            return FakeBlob(name)
+
+    class FakeClient:
+        def bucket(self, name):
+            return FakeBucket(name)
+
+    monkeypatch.setattr(storage_service.storage, "Client", lambda: FakeClient())
+    monkeypatch.setattr(storage_service.settings, "S3_BUCKET_NAME", "gcs-bucket")
+
+    service = storage_service.GCSStorageService()
+    payload = io.BytesIO(b"hello-gcs")
+
+    service.upload("file.txt", payload)
+
+    assert uploaded == {"name": "file.txt", "content": b"hello-gcs"}
+    assert service.get_public_url("file.txt") == "https://storage.googleapis.com/gcs-bucket/file.txt"


### PR DESCRIPTION
### Motivation
- Provide unit coverage for service-level utilities that previously lacked tests, focusing on LLM calls, storage backends, and the in-memory database implementation.
- Exercise both success and failure/error paths to ensure observability/logging and usage accounting behave as expected.
- Avoid contacting external services by using isolated fakes/mocks for `litellm`, S3/GCS clients, and database operations.

### Description
- Added test module `tests/unit/services/test_llm_service.py` that mocks `litellm.acompletion` to validate successful response parsing, usage accounting via `user_service.add_usage`, and exception logging via `get_observability_service`.
- Added `tests/unit/services/test_storage_service.py` which fakes an S3 client and a GCS client to validate `S3StorageService.upload`/`get_public_url` and `GCSStorageService.upload`/`get_public_url` behavior without network access.
- Added `tests/unit/services/test_memory_database_service.py` to validate `MemoryDBService` CRUD semantics and error handling for missing documents.
- Created test package initializer at `tests/unit/services/__init__.py` and committed the new test files.

### Testing
- No automated test suite was executed as part of this change (tests were added but not run).
- The change only introduces new test files and uses `monkeypatch`/fakes to isolate external dependencies during unit runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eba37bb2483239fdb73b43f0dd59d)