### PR TITLE
Fix storage service import and silence pytest dependency warnings

### DIFF
--- a/webapp/packages/api/user-service/pytest.ini
+++ b/webapp/packages/api/user-service/pytest.ini
@@ -4,6 +4,10 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 asyncio_mode = auto
+filterwarnings =
+    ignore:pkg_resources is deprecated as an API:DeprecationWarning:pkg_resources
+    ignore:Deprecated call to `pkg_resources.declare_namespace`:DeprecationWarning:pkg_resources
+    ignore:You are using a Python version .* which Google will stop supporting:FutureWarning:google\.api_core\._python_version_support
 
 # Markers for test organization
 markers =

--- a/webapp/packages/api/user-service/services/storage_service.py
+++ b/webapp/packages/api/user-service/services/storage_service.py
@@ -1,6 +1,6 @@
 import boto3
 from botocore.client import Config
-from ..config import settings
+from config import settings
 from google.cloud import storage
 
 class StorageService:


### PR DESCRIPTION
### Motivation
- Tests were failing during collection due to an `ImportError` caused by a relative import used from within the `services` package.
- Test output contained noisy deprecation and compatibility warnings from third-party dependencies that obscure test results.

### Description
- Replace the problematic relative import in `services/storage_service.py` by importing settings with `from config import settings` to avoid "attempted relative import beyond top-level package" errors.
- Add `filterwarnings` entries to `pytest.ini` to ignore known `pkg_resources` deprecation warnings and the Google `FutureWarning` about Python version support.
- No other runtime behavior or storage logic was changed.

### Testing
- Running `pytest` prior to the change failed during collection with an `ImportError: attempted relative import beyond top-level package` (test collection error).
- The test run also emitted `DeprecationWarning` and `FutureWarning` messages from third-party packages which are now filtered.
- No automated tests were executed after these changes in this rollout (changes committed but `pytest` was not re-run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ebb94238c8323b7ebc2de2b5f9335)